### PR TITLE
Fix auth0 domain in .env.example

### DIFF
--- a/ts-langchain/.env.example
+++ b/ts-langchain/.env.example
@@ -7,7 +7,7 @@ LANGCHAIN_CALLBACKS_BACKGROUND=false
 # Auth0 configuration
 APP_BASE_URL="http://localhost:3000"
 AUTH0_SECRET="use [openssl rand -hex 32] to generate a 32 bytes value"
-AUTH0_DOMAIN="https://{yourDomain}"
+AUTH0_DOMAIN="{yourDomain}"
 AUTH0_CLIENT_ID="{yourClientId}"
 AUTH0_CLIENT_SECRET="{yourClientSecret}"
 

--- a/ts-llamaindex/.env.example
+++ b/ts-llamaindex/.env.example
@@ -7,7 +7,7 @@ LANGCHAIN_CALLBACKS_BACKGROUND=false
 # Auth0 configuration
 APP_BASE_URL="http://localhost:3000"
 AUTH0_SECRET="use [openssl rand -hex 32] to generate a 32 bytes value"
-AUTH0_DOMAIN="https://{yourDomain}"
+AUTH0_DOMAIN="{yourDomain}"
 AUTH0_CLIENT_ID="{yourClientId}"
 AUTH0_CLIENT_SECRET="{yourClientSecret}"
 

--- a/ts-vercel-ai/.env.example
+++ b/ts-vercel-ai/.env.example
@@ -7,7 +7,7 @@ LANGCHAIN_CALLBACKS_BACKGROUND=false
 # Auth0 configuration
 APP_BASE_URL="http://localhost:3000"
 AUTH0_SECRET="use [openssl rand -hex 32] to generate a 32 bytes value"
-AUTH0_DOMAIN="https://{yourDomain}"
+AUTH0_DOMAIN="{yourDomain}"
 AUTH0_CLIENT_ID="{yourClientId}"
 AUTH0_CLIENT_SECRET="{yourClientSecret}"
 


### PR DESCRIPTION
Fixes the placeholders for `AUTH0_DOMAIN` in `.env.example`, as the domain value should not have the scheme (`https://`).