### PR TITLE
[AIDX-304] fix: updated package links in readme file

### DIFF
--- a/py-langchain/README.md
+++ b/py-langchain/README.md
@@ -7,7 +7,7 @@ Assistant0 an AI personal assistant that consolidates your digital life by dynam
 This template scaffolds an Auth0 + LangChain.js + Next.js starter app. It mainly uses the following libraries:
 
 - [LangChain's Python framework](https://python.langchain.com/docs/introduction/) and [LangGraph.js](https://langchain-ai.github.io/langgraph/) for building agentic workflows.
-- The [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-python) and [Auth0 FastAPI SDK](https://github.com/auth0/auth0-fastapi) to secure the application and call third-party APIs.
+- The [Auth0 AI SDK](https://github.com/auth0/auth0-ai-python) and [Auth0 FastAPI SDK](https://github.com/auth0/auth0-fastapi) to secure the application and call third-party APIs.
 - [Auth0 FGA](https://auth0.com/fine-grained-authorization) to define fine-grained access control policies for your tools and RAG pipelines.
 
 ## 🚀 Getting Started

--- a/ts-langchain/README.md
+++ b/ts-langchain/README.md
@@ -9,7 +9,7 @@ Assistant0 an AI personal assistant that consolidates your digital life by dynam
 This template scaffolds an Auth0 + LangChain.js + Next.js starter app. It mainly uses the following libraries:
 
 - [LangChain's JavaScript framework](https://js.langchain.com/docs/introduction/) and [LangGraph.js](https://langchain-ai.github.io/langgraphjs/) for building agentic workflows.
-- The [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
+- The [Auth0 AI SDK](https://github.com/auth0/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
 - [Auth0 FGA](https://auth0.com/fine-grained-authorization) to define fine-grained access control policies for your tools and RAG pipelines.
 - Postgres with [Drizzle ORM](https://orm.drizzle.team/) and [pgvector](https://github.com/pgvector/pgvector) to store the documents and embeddings.
 

--- a/ts-llamaindex/README.md
+++ b/ts-llamaindex/README.md
@@ -10,7 +10,7 @@ This template scaffolds an Auth0 + Next.js starter app. It mainly uses the follo
 
 - [LlamaIndex](https://www.llamaindex.ai/) to handle the AI agent and embedding functionalities.
 - Vercel's [AI SDK](https://github.com/vercel-labs/ai) to handle the UI and streaming responses.
-- The [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
+- The [Auth0 AI SDK](https://github.com/auth0/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
 - [Auth0 FGA](https://auth0.com/fine-grained-authorization) to define fine-grained access control policies for your tools and RAG pipelines.
 - Postgres with [Drizzle ORM](https://orm.drizzle.team/) and [pgvector](https://github.com/pgvector/pgvector) to store the documents and embeddings.
 

--- a/ts-vercel-ai/README.md
+++ b/ts-vercel-ai/README.md
@@ -9,7 +9,7 @@ Assistant0 an AI personal assistant that consolidates your digital life by dynam
 This template scaffolds an Auth0 + Next.js starter app. It mainly uses the following libraries:
 
 - Vercel's [AI SDK](https://github.com/vercel-labs/ai) to handle the AI agent.
-- The [Auth0 AI SDK](https://github.com/auth0-lab/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
+- The [Auth0 AI SDK](https://github.com/auth0/auth0-ai-js) and [Auth0 Next.js SDK](https://github.com/auth0/nextjs-auth0) to secure the application and call third-party APIs.
 - [Auth0 FGA](https://auth0.com/fine-grained-authorization) to define fine-grained access control policies for your tools and RAG pipelines.
 - Postgres with [Drizzle ORM](https://orm.drizzle.team/) and [pgvector](https://github.com/pgvector/pgvector) to store the documents and embeddings.
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Updated package links in readme file containing wrong repo:
`auth0-lab/auth0-ai-` -> `auth0/auth0-ai-`


### References

[AIDX-304](https://auth0team.atlassian.net/browse/AIDX-304)


[AIDX-304]: https://auth0team.atlassian.net/browse/AIDX-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ