### PR TITLE
fix: patch @auth0/ai, @auth0/ai-vercel to 5.0.1, 4.0.1

### DIFF
--- a/py-langchain/frontend/package-lock.json
+++ b/py-langchain/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@auth0/ai": "^5.0.0",
+        "@auth0/ai": "^5.0.1",
         "@langchain/core": "^0.3.66",
         "@langchain/langgraph-sdk": "^0.0.109",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@auth0/ai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.0.tgz",
-      "integrity": "sha512-lvMXNup/vkpA+gWu0Bs2MouM0P5hNpIWInZQwkGmyd5LCBEDN1MbZprdeBj0b/KgfdkaLu+psTDXbPCIB9AugQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.1.tgz",
+      "integrity": "sha512-l5lGBOlV6nRBPsevIZli0GGAjfQwrwhCFp0NvK3RcGmwbzOqua2gDvulhr6JHIAF3LFi2xcyq4/GY3l7btxzfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openfga/sdk": "^0.8.0",

--- a/py-langchain/frontend/package.json
+++ b/py-langchain/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@auth0/ai": "^5.0.0",
+    "@auth0/ai": "^5.0.1",
     "@langchain/core": "^0.3.66",
     "@langchain/langgraph-sdk": "^0.0.109",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/ts-langchain/package-lock.json
+++ b/ts-langchain/package-lock.json
@@ -122,9 +122,9 @@
       "peer": true
     },
     "node_modules/@auth0/ai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.0.tgz",
-      "integrity": "sha512-lvMXNup/vkpA+gWu0Bs2MouM0P5hNpIWInZQwkGmyd5LCBEDN1MbZprdeBj0b/KgfdkaLu+psTDXbPCIB9AugQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.1.tgz",
+      "integrity": "sha512-l5lGBOlV6nRBPsevIZli0GGAjfQwrwhCFp0NvK3RcGmwbzOqua2gDvulhr6JHIAF3LFi2xcyq4/GY3l7btxzfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openfga/sdk": "^0.8.0",

--- a/ts-llamaindex/package-lock.json
+++ b/ts-llamaindex/package-lock.json
@@ -11,7 +11,7 @@
         "@ai-sdk/llamaindex": "^1.0.28",
         "@ai-sdk/react": "2.0.33",
         "@auth0/ai-llamaindex": "^4.0.0",
-        "@auth0/ai-vercel": "^4.0.0",
+        "@auth0/ai-vercel": "^4.0.1",
         "@auth0/nextjs-auth0": "4.9.0",
         "@langchain/community": "^0.3.53",
         "@llamaindex/openai": "^0.4.18",
@@ -252,9 +252,9 @@
       "peer": true
     },
     "node_modules/@auth0/ai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.0.tgz",
-      "integrity": "sha512-lvMXNup/vkpA+gWu0Bs2MouM0P5hNpIWInZQwkGmyd5LCBEDN1MbZprdeBj0b/KgfdkaLu+psTDXbPCIB9AugQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.1.tgz",
+      "integrity": "sha512-l5lGBOlV6nRBPsevIZli0GGAjfQwrwhCFp0NvK3RcGmwbzOqua2gDvulhr6JHIAF3LFi2xcyq4/GY3l7btxzfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openfga/sdk": "^0.8.0",
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/@auth0/ai-vercel": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai-vercel/-/ai-vercel-4.0.0.tgz",
-      "integrity": "sha512-ta2EPCrkWL9gv47fgmWEZTlGKZ1LySMkiqmKXD96V7/elQ27IHxYkyJ59P5s4D6YxqUrT6zQ6Vo+rxSlFNOerw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai-vercel/-/ai-vercel-4.0.1.tgz",
+      "integrity": "sha512-dktgjXLXngRkYnLsySClfgyA4FEb0Gr8Q1gH1PPdx0mcQVWfRkVG6tcvdU3ziThP9RvxkmcmPTyU0Mxv+dTwug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/react": "^2.0.0",
@@ -450,16 +450,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild-kit/core-utils": {

--- a/ts-llamaindex/package.json
+++ b/ts-llamaindex/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/llamaindex": "^1.0.28",
     "@ai-sdk/react": "2.0.33",
     "@auth0/ai-llamaindex": "^4.0.0",
-    "@auth0/ai-vercel": "^4.0.0",
+    "@auth0/ai-vercel": "^4.0.1",
     "@auth0/nextjs-auth0": "4.9.0",
     "@langchain/community": "^0.3.53",
     "@llamaindex/openai": "^0.4.18",

--- a/ts-vercel-ai/package-lock.json
+++ b/ts-vercel-ai/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ai-sdk/openai": "2.0.24",
         "@ai-sdk/react": "2.0.33",
-        "@auth0/ai-vercel": "^4.0.0",
+        "@auth0/ai-vercel": "^4.0.1",
         "@auth0/nextjs-auth0": "4.4.2",
         "@langchain/community": "^0.3.53",
         "@radix-ui/react-avatar": "^1.1.7",
@@ -201,9 +201,9 @@
       "peer": true
     },
     "node_modules/@auth0/ai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.0.tgz",
-      "integrity": "sha512-lvMXNup/vkpA+gWu0Bs2MouM0P5hNpIWInZQwkGmyd5LCBEDN1MbZprdeBj0b/KgfdkaLu+psTDXbPCIB9AugQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai/-/ai-5.0.1.tgz",
+      "integrity": "sha512-l5lGBOlV6nRBPsevIZli0GGAjfQwrwhCFp0NvK3RcGmwbzOqua2gDvulhr6JHIAF3LFi2xcyq4/GY3l7btxzfQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openfga/sdk": "^0.8.0",
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@auth0/ai-vercel": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@auth0/ai-vercel/-/ai-vercel-4.0.0.tgz",
-      "integrity": "sha512-ta2EPCrkWL9gv47fgmWEZTlGKZ1LySMkiqmKXD96V7/elQ27IHxYkyJ59P5s4D6YxqUrT6zQ6Vo+rxSlFNOerw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@auth0/ai-vercel/-/ai-vercel-4.0.1.tgz",
+      "integrity": "sha512-dktgjXLXngRkYnLsySClfgyA4FEb0Gr8Q1gH1PPdx0mcQVWfRkVG6tcvdU3ziThP9RvxkmcmPTyU0Mxv+dTwug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/react": "^2.0.0",

--- a/ts-vercel-ai/package.json
+++ b/ts-vercel-ai/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@ai-sdk/openai": "2.0.24",
     "@ai-sdk/react": "2.0.33",
-    "@auth0/ai-vercel": "^4.0.0",
+    "@auth0/ai-vercel": "^4.0.1",
     "@auth0/nextjs-auth0": "4.4.2",
     "@langchain/community": "^0.3.53",
     "@radix-ui/react-avatar": "^1.1.7",


### PR DESCRIPTION
Patches @auth0/ai to @5.0.1 and @auth0/ai-vercel to @4.0.1 in all examples.

see:
https://github.com/auth0/auth0-ai-js/pull/297