### PR TITLE
feat: deprecate @langchain/community google cal tools

### DIFF
--- a/ts-langchain/src/lib/agent.ts
+++ b/ts-langchain/src/lib/agent.ts
@@ -4,13 +4,12 @@ import { InMemoryStore, MemorySaver } from '@langchain/langgraph';
 import { Calculator } from '@langchain/community/tools/calculator';
 import { SerpAPI } from '@langchain/community/tools/serpapi';
 import { GmailCreateDraft, GmailSearch } from '@langchain/community/tools/gmail';
-import { GoogleCalendarCreateTool, GoogleCalendarViewTool } from '@langchain/community/tools/google_calendar';
 
-import { getAccessToken, withCalendar, withGmailRead, withGmailWrite, withAsyncAuthorization } from './auth0-ai';
+import { withCalendar, withGmailRead, withGmailWrite, withAsyncAuthorization } from './auth0-ai';
 import { getUserInfoTool } from './tools/user-info';
 import { shopOnlineTool } from './tools/shop-online';
 import { getContextDocumentsTool } from './tools/context-docs';
-import { getCalendarEventsTool } from './tools/google-calender';
+import { getCalendarEventsTool, createCalendarEventsTool } from './tools/google-calender';
 
 const date = new Date().toISOString();
 
@@ -24,23 +23,21 @@ const llm = new ChatOpenAI({
 // Provide the access token to the Gmail tools
 const gmailParams = {
   credentials: {
-    accessToken: getAccessToken,
+    accessToken: async () => {
+      const { getAccessToken } = await import('./auth0-ai');
+      return getAccessToken();
+    },
   },
 };
 
-const googleCalendarParams = {
-  credentials: { accessToken: getAccessToken, calendarId: 'primary' },
-  model: llm,
-};
 const tools = [
   new Calculator(),
   // Requires process.env.SERPAPI_API_KEY to be set: https://serpapi.com/
   new SerpAPI(),
   withGmailRead(new GmailSearch(gmailParams)),
   withGmailWrite(new GmailCreateDraft(gmailParams)),
-  withCalendar(new GoogleCalendarCreateTool(googleCalendarParams)),
-  withCalendar(new GoogleCalendarViewTool(googleCalendarParams)),
   withCalendar(getCalendarEventsTool),
+  withCalendar(createCalendarEventsTool),
   getUserInfoTool,
   withAsyncAuthorization(shopOnlineTool),
   getContextDocumentsTool,


### PR DESCRIPTION
Deprecates usage of the lesser maintained `@langchain/community/tools/google_calendar`, which are currently causing issues w/ the zod schemas supported by the OpenAI LLM models references here ([zod schemas](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain-community/src/tools/google_calendar/commands/run-view-events.ts#L10-L16) here have become dated & do not include `.nullable()` with `.optional()` fields). 

error when this tool is currently used:
```
intercept-console-error.ts:41 StreamError: Zod field at `#/definitions/extract/properties/search_query` uses `.optional()` without `.nullable()` which is not supported by the API. See: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required
  at consumeStream (stream.js:453:35)
  at async Object.submit (stream.js:555:9)
```

We've made a similar update already in [here](https://github.com/auth0-samples/auth0-assistant0/blob/main/ts-langchain/src/lib/tools/google-calender.ts) and in [auth0-ai-samples](https://github.com/auth0-samples/auth0-ai-samples/blob/main/call-apis-on-users-behalf/others-api/langchain-react-spa-js/apps/agents/src/memory-agent/tools/view-calendar-events.ts).

Tested the inline view and create google cal tools introduced here to work as expected now.

Screenshots:
**View:**
<img width="1392" height="1527" alt="Screenshot 2025-11-12 at 5 44 38 PM" src="https://github.com/user-attachments/assets/69052276-8109-4c64-902a-0ae77e379976" />

**Create:**
<img width="1392" height="1527" alt="Screenshot 2025-11-12 at 5 46 21 PM" src="https://github.com/user-attachments/assets/d3213da5-4163-498b-8804-c8f571274b58" />

<img width="431" height="271" alt="Screenshot 2025-11-12 at 5 46 17 PM" src="https://github.com/user-attachments/assets/ffefd331-38c8-419a-a0c3-0953969abe84" />

